### PR TITLE
Mocha: Extend tests to validate status codes

### DIFF
--- a/tests/jpeg-processing.test.ts
+++ b/tests/jpeg-processing.test.ts
@@ -1,9 +1,27 @@
 import assert from 'node:assert/strict';
 import * as fs from 'node:fs/promises';
 import { Asset, JUMBF, Manifest } from '../src';
+import { ValidationResult, ValidationStatusCode } from '../src/manifest';
 
 // location of the JPEG images within the checked out test files repo
 const baseDir = 'public-testfiles/image/jpeg';
+
+class TestExpectations {
+    /**
+     * whether the file contains a JUMBF with a C2PA Manifest
+     */
+    jumbf = false;
+
+    /**
+     * whether the file is valid according to the C2PA Manifest
+     */
+    valid: boolean | undefined = undefined;
+
+    /**
+     * status codes expected in the status entries
+     */
+    statusCodes: ValidationStatusCode[] = [];
+}
 
 // test data sets with file names and expected outcomes
 const testFiles = {
@@ -42,6 +60,7 @@ const testFiles = {
     'adobe-20220124-CAIAIIICAICIICAIICICA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionActionIngredientMismatch],
     },
     'adobe-20220124-CI.jpg': {
         jumbf: true,
@@ -54,6 +73,7 @@ const testFiles = {
     'adobe-20220124-CICACACA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionActionIngredientMismatch],
     },
     'adobe-20220124-CIE-sig-CA.jpg': {
         jumbf: true,
@@ -67,18 +87,25 @@ const testFiles = {
     'adobe-20220124-E-clm-CAICAI.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [
+            ValidationStatusCode.AssertionHashedURIMismatch,
+            ValidationStatusCode.AssertionActionIngredientMismatch,
+        ],
     },
     'adobe-20220124-E-dat-CA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionDataHashMismatch],
     },
     'adobe-20220124-E-sig-CA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.ClaimSignatureMismatch],
     },
     'adobe-20220124-E-uri-CA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionHashedURIMismatch],
     },
     'adobe-20220124-E-uri-CIE-sig-CA.jpg': {
         jumbf: true,
@@ -91,10 +118,12 @@ const testFiles = {
     'adobe-20220124-XCA.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionDataHashMismatch],
     },
     'adobe-20220124-XCI.jpg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.AssertionDataHashMismatch],
     },
     'adobe-20221004-ukraine_building.jpeg': {
         jumbf: true,
@@ -103,6 +132,7 @@ const testFiles = {
     'nikon-20221019-building.jpeg': {
         jumbf: true,
         valid: false,
+        statusCodes: [ValidationStatusCode.SigningCredentialExpired],
     },
     'truepic-20230212-camera.jpg': {
         jumbf: true,
@@ -119,7 +149,8 @@ const testFiles = {
 };
 
 describe('Functional JPEG Reading Tests', function () {
-    for (const [filename, data] of Object.entries(testFiles)) {
+    for (const [filename, test] of Object.entries(testFiles)) {
+        const data = Object.assign(new TestExpectations(), test);
         describe(`test file ${filename}`, () => {
             let buf: Buffer | undefined = undefined;
             it(`loading test file`, async () => {
@@ -157,6 +188,7 @@ describe('Functional JPEG Reading Tests', function () {
             });
 
             if (data.jumbf) {
+                let validationResult: ValidationResult | undefined = undefined;
                 it(`validate manifest`, async function () {
                     if (!jumbf || !asset) {
                         this.skip();
@@ -169,8 +201,21 @@ describe('Functional JPEG Reading Tests', function () {
                     const manifests = Manifest.ManifestStore.read(superBox);
 
                     // Validate the asset with the manifest
-                    const validationResult = await manifests.validate(asset);
+                    validationResult = await manifests.validate(asset);
                     assert.equal(validationResult.isValid, data.valid);
+                });
+
+                data.statusCodes.forEach(value => {
+                    it(`check status code ${value}`, async function () {
+                        if (validationResult === undefined) {
+                            this.skip();
+                        }
+
+                        assert.ok(
+                            validationResult.statusEntries.some(entry => entry.code === value),
+                            `missing status code ${value}`,
+                        );
+                    });
                 });
             }
         });


### PR DESCRIPTION
Instead of only checking the boolean `valid` result of validation, check for specific status codes as well. In particular check that invalid files emit the correct reason why they are invalid.
