### PR TITLE
UUIDBox: Fix parsing

### DIFF
--- a/src/jumbf/UUIDBox.ts
+++ b/src/jumbf/UUIDBox.ts
@@ -11,7 +11,10 @@ export class UUIDBox extends Box {
     }
 
     public parse(buf: Uint8Array) {
-        this.content = buf;
+        if (buf.length < 16) throw new Error('UUIDBox: Data too short');
+
+        this.uuid = buf.subarray(0, 16);
+        this.content = buf.subarray(16);
     }
 
     public toString(prefix?: string | undefined): string {


### PR DESCRIPTION
This stored all input data as payload. However, the first 16 bytes are a UUID and only the rest is actual payload.