### PR TITLE
Use cbor-x instead of cbor-js for CBOR encoding/decoding

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@peculiar/x509": "^1.11.0",
-        "cbor-js": "^0.1.0",
+        "cbor-x": "^1.5.9",
         "crc-32": "^1.2.2",
         "pkijs": "^3.2.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.7.0",
         "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
-        "@types/cbor-js": "^0.1.1",
         "@types/eslint__js": "^8.42.3",
         "@types/mocha": "^10.0.7",
         "@types/node": "^20.14.11",
@@ -515,6 +514,84 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-arm64/-/cbor-extract-darwin-arm64-2.2.0.tgz",
+      "integrity": "sha512-P7swiOAdF7aSi0H+tHtHtr6zrpF3aAq/W9FXx5HektRvLTM2O89xCyXF3pk7pLc7QpaY7AoaE8UowVf9QBdh3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-darwin-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-darwin-x64/-/cbor-extract-darwin-x64-2.2.0.tgz",
+      "integrity": "sha512-1liF6fgowph0JxBbYnAS7ZlqNYLf000Qnj4KjqPNW4GViKrEql2MgZnAsExhY9LSy8dnvA4C0qHEBgPrll0z0w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm/-/cbor-extract-linux-arm-2.2.0.tgz",
+      "integrity": "sha512-QeBcBXk964zOytiedMPQNZr7sg0TNavZeuUCD6ON4vEOU/25+pLhNN6EDIKJ9VLTKaZ7K7EaAriyYQ1NQ05s/Q==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-arm64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-arm64/-/cbor-extract-linux-arm64-2.2.0.tgz",
+      "integrity": "sha512-rQvhNmDuhjTVXSPFLolmQ47/ydGOFXtbR7+wgkSY0bdOxCFept1hvg59uiLPT2fVDuJFuEy16EImo5tE2x3RsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-linux-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-linux-x64/-/cbor-extract-linux-x64-2.2.0.tgz",
+      "integrity": "sha512-cWLAWtT3kNLHSvP4RKDzSTX9o0wvQEEAj4SKvhWuOVZxiDAeQazr9A+PSiRILK1VYMLeDml89ohxCnUNQNQNCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@cbor-extract/cbor-extract-win32-x64": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cbor-extract/cbor-extract-win32-x64/-/cbor-extract-win32-x64-2.2.0.tgz",
+      "integrity": "sha512-l2M+Z8DO2vbvADOBNLbbh9y5ST1RY5sqkWOg/58GkUPBYou/cuNZ68SGQ644f1CvZ8kcOxyZtw06+dxWHIoN/w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1450,13 +1527,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/cbor-js": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@types/cbor-js/-/cbor-js-0.1.1.tgz",
-      "integrity": "sha512-pfCx/EZC7VNBThwAQ0XvGPOXYm8BUk+gSVonaIGcEKBuqGJHTdcwAGW8WZkdRs/u9n9yOt1pBoPTCS1s8ZYpEQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/eslint": {
       "version": "8.56.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.10.tgz",
@@ -1999,10 +2069,36 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cbor-js": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
-      "integrity": "sha512-7sQ/TvDZPl7csT1Sif9G0+MA0I0JOVah8+wWlJVQdVEgIbCzlN/ab3x+uvMNsc34TUvO6osQTAmB2ls80JX6tw=="
+    "node_modules/cbor-extract": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cbor-extract/-/cbor-extract-2.2.0.tgz",
+      "integrity": "sha512-Ig1zM66BjLfTXpNgKpvBePq271BPOvu8MR0Jl080yG7Jsl+wAZunfrwiwA+9ruzm/WEdIV5QF/bjDZTqyAIVHA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.1.1"
+      },
+      "bin": {
+        "download-cbor-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@cbor-extract/cbor-extract-darwin-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-darwin-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-arm64": "2.2.0",
+        "@cbor-extract/cbor-extract-linux-x64": "2.2.0",
+        "@cbor-extract/cbor-extract-win32-x64": "2.2.0"
+      }
+    },
+    "node_modules/cbor-x": {
+      "version": "1.5.9",
+      "resolved": "https://registry.npmjs.org/cbor-x/-/cbor-x-1.5.9.tgz",
+      "integrity": "sha512-OEI5rEu3MeR0WWNUXuIGkxmbXVhABP+VtgAXzm48c9ulkrsvxshjjk94XSOGphyAKeNGLPfAxxzEtgQ6rEVpYQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "cbor-extract": "^2.2.0"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2176,6 +2272,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/diff": {
       "version": "5.2.0",
@@ -3434,6 +3540,21 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.1.1.tgz",
+      "integrity": "sha512-+P72GAjVAbTxjjwUmwjVrqrdZROD4nf8KgpBoDxqXXTiYZZt/ud60dE5yvCSr9lRO8e8yv6kgJIC0K0PfZFVQw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.14",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "devDependencies": {
     "@eslint/js": "^9.7.0",
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
-    "@types/cbor-js": "^0.1.1",
     "@types/eslint__js": "^8.42.3",
     "@types/mocha": "^10.0.7",
     "@types/node": "^20.14.11",
@@ -53,7 +52,7 @@
   },
   "dependencies": {
     "@peculiar/x509": "^1.11.0",
-    "cbor-js": "^0.1.0",
+    "cbor-x": "^1.5.9",
     "crc-32": "^1.2.2",
     "pkijs": "^3.2.1"
   },

--- a/src/cose/SigStructure.ts
+++ b/src/cose/SigStructure.ts
@@ -1,4 +1,4 @@
-import cbor from 'cbor-js';
+import * as cbor from 'cbor-x';
 
 export class SigStructure {
     public readonly externalAAD: Uint8Array = new Uint8Array(0);
@@ -10,6 +10,11 @@ export class SigStructure {
     ) {}
 
     public encode(): Uint8Array {
-        return new Uint8Array(cbor.encode([this.context, this.protectedBucket, this.externalAAD, this.payload]));
+        return new cbor.Encoder({ tagUint8Array: false }).encode([
+            this.context,
+            this.protectedBucket,
+            this.externalAAD,
+            this.payload,
+        ]);
     }
 }

--- a/src/cose/Signature.ts
+++ b/src/cose/Signature.ts
@@ -11,7 +11,7 @@ import {
     SubjectKeyIdentifierExtension,
     X509Certificate,
 } from '@peculiar/x509';
-import cbor from 'cbor-js';
+import * as cbor from 'cbor-x';
 import { PKIStatus, SignedData, TimeStampResp, TSTInfo } from 'pkijs';
 import { Crypto, ECDSANamedCurve, HashAlgorithm, SigningAlgorithm } from '../crypto';
 import * as JUMBF from '../jumbf';
@@ -35,7 +35,7 @@ export class Signature {
 
         let protectedBucket: ProtectedBucket | undefined;
         try {
-            protectedBucket = cbor.decode(BinaryHelper.toArrayBuffer(rawContent[0])) as ProtectedBucket;
+            protectedBucket = cbor.decode(rawContent[0]) as ProtectedBucket;
         } catch {
             /* empty */
         }

--- a/src/jumbf/CBORBox.ts
+++ b/src/jumbf/CBORBox.ts
@@ -1,5 +1,4 @@
-import cbor from 'cbor-js';
-import { BinaryHelper } from '../util';
+import * as cbor from 'cbor-x';
 import { Box } from './Box';
 
 export class CBORBox extends Box {
@@ -14,7 +13,12 @@ export class CBORBox extends Box {
     public parse(buf: Uint8Array) {
         this.rawContent = buf;
         try {
-            this.content = cbor.decode(BinaryHelper.toArrayBuffer(buf));
+            this.content = cbor.decode(buf);
+
+            // Ignore unknown CBOR tags
+            if (this.content instanceof cbor.Tag) {
+                this.content = this.content.value;
+            }
         } catch {
             // TODO This needs to be properly reported as a validation error
             throw new Error('CBORBox: Invalid CBOR data');


### PR DESCRIPTION
Switch to newer, well maintained library cbor-x that includes proper tagging support.

It's pretty straightforward. Only two adjustments were necessary:
* `src/cose/SigStructure.ts` shows an example of CBOR encoding – it needs a special flag to properly encode Uint8Array to the format we need.
* `src/jumbf/CBORBox.ts` needs to deal with the fact that cbor-x returns a special `Tag` object when encountering CBOR tags it doesn't natively understand.