### PR TITLE
ManifestStore: Reject manifest store boxes without URI

### DIFF
--- a/src/manifest/ManifestStore.ts
+++ b/src/manifest/ManifestStore.ts
@@ -42,6 +42,12 @@ export class ManifestStore {
                 superBox,
                 'Manifest store has wrong UUID',
             );
+        if (!superBox.descriptionBox.label)
+            throw new ValidationError(
+                ValidationStatusCode.ClaimRequiredMissing,
+                superBox,
+                'Manifest store box is missing the label',
+            );
 
         superBox.contentBoxes
             .filter((box): box is JUMBF.SuperBox => box instanceof JUMBF.SuperBox)


### PR DESCRIPTION
There is no test code yet (I hacked something into the JPEG functional tests to verify this), that should probably become part of developing code for creating the manifests. This one was the only one I found that didn't catch missing URIs.
