### PR TITLE
Fix build errors

### DIFF
--- a/.changeset/slow-penguins-sort.md
+++ b/.changeset/slow-penguins-sort.md
@@ -1,0 +1,5 @@
+---
+'@trustnxt/c2pa-ts': patch
+---
+
+Fix build errors

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "lint": "eslint src tests",
     "format": "prettier --write src tests",
     "test": "mocha 'tests/**/*test.ts'",
-    "build": "rimraf dist && node prebuild.js && tsc -p tsconfig.json; node postbuild.js",
+    "build": "rimraf dist && node prebuild.js && tsc -p tsconfig.json; exit_code=$?; node postbuild.js; exit $exit_code",
     "changeset": "changeset",
     "version": "changeset version && npm install --package-lock-only",
     "release": "npm run build && changeset publish"

--- a/src/jumbf/schemata.ts
+++ b/src/jumbf/schemata.ts
@@ -32,7 +32,7 @@ export const type = new JUMBFTypeCodeSchema();
 
 // type field for UUIDs
 class JUMBFUUIDSchema extends bin.Schema<Uint8Array> {
-    private uuid = bin.u8Array(16);
+    readonly uuid = bin.u8Array(16);
 
     read(input: bin.ISerialInput): Uint8Array {
         return this.uuid.read(input);


### PR DESCRIPTION
Also make sure the exit code of the build isn't accidentally swallowed by the postbuild script.