### PR TITLE
Support additional assertions

### DIFF
--- a/.changeset/pink-deers-divide.md
+++ b/.changeset/pink-deers-divide.md
@@ -1,0 +1,5 @@
+---
+'@trustnxt/c2pa-ts': minor
+---
+
+Support additional assertions (Training and Data Mining, CAWG Metadata)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Anything that's not listed below is not currently planned to be implemented.
 - :white_check_mark: Ingredient
 - :white_check_mark: Metadata (specialized, common, generic, and CAWG variants)
 - :white_check_mark: Creative Work
-- :x: Training and Data Mining (C2PA and CAWG variants)
+- :white_check_mark: Training and Data Mining (C2PA and CAWG variants)
 - :x: CAWG Identity
 
 ### JUMBF boxes

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Anything that's not listed below is not currently planned to be implemented.
 
 :information_source: On C2PA versions: The library is targeted at C2PA specification 2.0, however data structures from older versions of the specification are also supported for backwards compatibility.
 
+:information_source: Although it is a separate project from C2PA, the library also includes support for several [CAWG](https://github.com/creator-assertions/) assertions.
+
 ### Asset file formats
 
 - :white_check_mark: JPEG
@@ -43,9 +45,10 @@ Anything that's not listed below is not currently planned to be implemented.
 - :white_check_mark: Thumbnail
 - :white_check_mark: Actions (except action templates and metadata)
 - :white_check_mark: Ingredient
-- :white_check_mark: Metadata
+- :white_check_mark: Metadata (specialized, common, generic, and CAWG variants)
 - :white_check_mark: Creative Work
-- :x: [CAWG](https://github.com/creator-assertions/) assertions
+- :x: Training and Data Mining (C2PA and CAWG variants)
+- :x: CAWG Identity
 
 ### JUMBF boxes
 

--- a/src/manifest/AssertionStore.ts
+++ b/src/manifest/AssertionStore.ts
@@ -68,11 +68,10 @@ export class AssertionStore implements ManifestComponent {
             assertion = new IngredientAssertion();
         } else if (AssertionLabels.metadataAssertions.includes(label.label)) {
             assertion = new MetadataAssertion();
-        } else if (
-            label.label === AssertionLabels.trainingAndDataMining ||
-            label.label === AssertionLabels.cawgTrainingAndDataMining
-        ) {
-            assertion = new TrainingAndDataMiningAssertion();
+        } else if (label.label === AssertionLabels.trainingAndDataMining) {
+            assertion = new TrainingAndDataMiningAssertion(false);
+        } else if (label.label === AssertionLabels.cawgTrainingAndDataMining) {
+            assertion = new TrainingAndDataMiningAssertion(true);
         } else if (
             box.descriptionBox.label.startsWith(AssertionLabels.thumbnailPrefix) ||
             box.descriptionBox.label.startsWith(AssertionLabels.ingredientThumbnailPrefix)

--- a/src/manifest/AssertionStore.ts
+++ b/src/manifest/AssertionStore.ts
@@ -7,6 +7,7 @@ import {
     DataHashAssertion,
     IngredientAssertion,
     MetadataAssertion,
+    TrainingAndDataMiningAssertion,
     UnknownAssertion,
 } from './assertions';
 import { AssertionLabels } from './assertions/AssertionLabels';
@@ -67,6 +68,11 @@ export class AssertionStore implements ManifestComponent {
             assertion = new IngredientAssertion();
         } else if (AssertionLabels.metadataAssertions.includes(label.label)) {
             assertion = new MetadataAssertion();
+        } else if (
+            label.label === AssertionLabels.trainingAndDataMining ||
+            label.label === AssertionLabels.cawgTrainingAndDataMining
+        ) {
+            assertion = new TrainingAndDataMiningAssertion();
         } else if (
             box.descriptionBox.label.startsWith(AssertionLabels.thumbnailPrefix) ||
             box.descriptionBox.label.startsWith(AssertionLabels.ingredientThumbnailPrefix)

--- a/src/manifest/assertions/AssertionLabels.ts
+++ b/src/manifest/assertions/AssertionLabels.ts
@@ -20,6 +20,8 @@ export class AssertionLabels {
 
     /** Generic JSON-LD based metadata assertion (C2PA 2.0) */
     public static readonly metadata = 'c2pa.metadata';
+    /** CAWG JSON-LD based metadata assertion */
+    public static readonly cawgMetadata = 'cawg.metadata';
     /** Common metadata assertion (deprecated as of C2PA 2.0) */
     public static readonly commonMetadata = 'stds.metadata';
     /** EXIF metadata assertion (deprecated as of C2PA 1.4) */
@@ -31,6 +33,7 @@ export class AssertionLabels {
     /** All JSON-LD based metadata assertions */
     public static readonly metadataAssertions = [
         AssertionLabels.metadata,
+        AssertionLabels.cawgMetadata,
         AssertionLabels.commonMetadata,
         AssertionLabels.exifMetadata,
         AssertionLabels.iptcMetadata,

--- a/src/manifest/assertions/AssertionLabels.ts
+++ b/src/manifest/assertions/AssertionLabels.ts
@@ -43,6 +43,11 @@ export class AssertionLabels {
     /** Schema.org based Creative Work assertion (deprecated as of C2PA 2.0) */
     public static readonly creativeWork = 'stds.schema-org.CreativeWork';
 
+    /** Training and Data Mining assertion (deprecated as of C2PA 2.0) */
+    public static readonly trainingAndDataMining = 'c2pa.training-mining';
+    /** CAWG Training and Data Mining assertion */
+    public static readonly cawgTrainingAndDataMining = 'cawg.training-mining';
+
     public static readonly thumbnailPrefix = 'c2pa.thumbnail.claim.';
     public static readonly ingredientThumbnailPrefix = 'c2pa.thumbnail.ingredient';
 }

--- a/src/manifest/assertions/TrainingAndDataMiningAssertion.ts
+++ b/src/manifest/assertions/TrainingAndDataMiningAssertion.ts
@@ -1,0 +1,66 @@
+import { CBORBox, IBox } from '../../jumbf';
+import { BinaryHelper } from '../../util';
+import * as raw from '../rawTypes';
+import { TrainingAndDataMiningChoice, TrainingAndDataMiningEntry, ValidationStatusCode } from '../types';
+import { ValidationError } from '../ValidationError';
+import { Assertion } from './Assertion';
+import { AssertionLabels } from './AssertionLabels';
+
+type RawTrainingMiningMap =
+    | Record<string, RawEntry>
+    | {
+          metadata?: raw.AssertionMetadataMap;
+      };
+
+interface RawEntry {
+    use: TrainingAndDataMiningChoice;
+    constraint_info?: string;
+}
+
+export class TrainingAndDataMiningAssertion extends Assertion {
+    public label = AssertionLabels.trainingAndDataMining;
+    public uuid = raw.UUIDs.cborAssertion;
+
+    public entries: Record<string, TrainingAndDataMiningEntry> = {};
+
+    public readContentFromJUMBF(box: IBox): void {
+        if (!(box instanceof CBORBox) || !this.uuid || !BinaryHelper.bufEqual(this.uuid, raw.UUIDs.cborAssertion))
+            throw new ValidationError(
+                ValidationStatusCode.AssertionRequiredMissing,
+                this.sourceBox,
+                'Training and Data Mining assertion has invalid type',
+            );
+
+        const content = box.content as RawTrainingMiningMap;
+
+        for (const [key, value] of Object.entries(content)) {
+            if (key === 'metadata') continue;
+
+            const entry = value as RawEntry;
+            if (!entry.use) continue;
+
+            this.entries[key] = {
+                choice: entry.use,
+                constraintInfo: entry.constraint_info,
+            };
+        }
+    }
+
+    public generateJUMBFBoxForContent(): IBox {
+        const entryKeys = Object.keys(this.entries).filter(key => key !== 'metadata');
+        if (!entryKeys.length) throw new Error('Assertion has no entries');
+
+        const content: Record<string, RawEntry> = {};
+        for (const key of entryKeys) {
+            const entry = this.entries[key];
+            content[key] = {
+                use: entry.choice,
+                constraint_info: entry.constraintInfo,
+            };
+        }
+
+        const box = new CBORBox();
+        box.content = content;
+        return box;
+    }
+}

--- a/src/manifest/assertions/index.ts
+++ b/src/manifest/assertions/index.ts
@@ -8,4 +8,5 @@ export * from './IngredientAssertion';
 export * from './MetadataAssertion';
 export * from './SchemaOrgAssertion';
 export * from './ThumbnailAssertion';
+export * from './TrainingAndDataMiningAssertion';
 export * from './UnknownAssertion';

--- a/src/manifest/types.ts
+++ b/src/manifest/types.ts
@@ -250,3 +250,28 @@ export enum ThumbnailType {
     Claim,
     Ingredient,
 }
+
+export enum TrainingAndDataMiningChoice {
+    Allowed = 'allowed',
+    NotAllowed = 'notAllowed',
+    Constrained = 'constrained',
+}
+
+export interface TrainingAndDataMiningEntry {
+    choice: TrainingAndDataMiningChoice;
+    constraintInfo?: string;
+}
+
+export enum TrainingAndDataMiningKey {
+    DataMining = 'c2pa.data_mining',
+    AIInference = 'c2pa.ai_inference',
+    AIGenerativeTraining = 'c2pa.ai_generative_training',
+    AITraining = 'c2pa.ai_training',
+}
+
+export enum CAWGTrainingAndDataMiningKey {
+    DataMining = 'cawg.data_mining',
+    AIInference = 'cawg.ai_inference',
+    AIGenerativeTraining = 'cawg.ai_generative_training',
+    AITraining = 'cawg.ai_training',
+}


### PR DESCRIPTION
* Add support for CAWG Metadata assertion
* Add support for CAWG Training and Data Mining assertion
* Add support for C2PA 1.x Training and Data Mining assertion

Note: There is some confusion in the specification about the layout of the payload (https://github.com/creator-assertions/training-and-data-mining-assertion/issues/3) so we try our best to be compatible with what other implementations seem to be doing.