### PR TITLE
ThumbnailAssertion: Use two underscores for suffixes

### DIFF
--- a/.changeset/eighty-olives-count.md
+++ b/.changeset/eighty-olives-count.md
@@ -1,0 +1,5 @@
+---
+'@trustnxt/c2pa-ts': patch
+---
+
+Use two underscores for ingredient thumbnail assertion suffix

--- a/src/manifest/assertions/ThumbnailAssertion.ts
+++ b/src/manifest/assertions/ThumbnailAssertion.ts
@@ -100,7 +100,7 @@ export class ThumbnailAssertion extends Assertion {
             assertion.label = AssertionLabels.thumbnailPrefix + imageType;
         } else {
             assertion.label =
-                AssertionLabels.ingredientThumbnailPrefix + (suffix ? '_' + suffix : '') + '.' + imageType;
+                AssertionLabels.ingredientThumbnailPrefix + (suffix ? '__' + suffix : '') + '.' + imageType;
         }
         return assertion;
     }


### PR DESCRIPTION
This is contradicting what the specification says, but consistent with the implementation in c2pa-rs. According to a CAI Discord conversation, the specification is wrong in this case.