### PR TITLE
Skip release workflow if triggered by dependabot

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   release:
     name: Release
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Workflows triggered by dependabot don't have access to actions secrets so the publish step will fail.