### PR TITLE
ActionAssertion: Fix field mappings for v1 and v2

### DIFF
--- a/.changeset/neat-trains-scream.md
+++ b/.changeset/neat-trains-scream.md
@@ -1,0 +1,5 @@
+---
+'@trustnxt/c2pa-ts': minor
+---
+
+Fix field mappings for actions assertion


### PR DESCRIPTION
- Remove invalid fields from v1 and v2 raw mappings
- Omit empty properties instead of setting to undefined
- Add test cases for v1 and v2 mappings